### PR TITLE
fix (SC-769): datalogger load binary checks for None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,5 @@ For instructions, see the [changelog confluence page](https://epcpower.atlassian
 
 ### Fixed
 
+- SC-769: Allow datalogger binary to load with empty SunSpec JSON
 - SC-734: revert pyelftools to pre-poetry version


### PR DESCRIPTION
## Jira Story

[SC-769](https://epcpower.atlassian.net/browse/SC-769)

## About

When performing "Load Binary" of a RMDC binary file, ST errors. More details in jira ticket.

## Associated Pull Requests

*   [ ] [stlib](https://github.com/epcpower/stlib/pull/39)

## Update Changelog

*   [x] Changelog updated

## Reproduction Steps

## Validation

Successfully load binary of example file.
